### PR TITLE
STEP8: Build Docker image using CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,10 +37,10 @@ jobs:
         echo 'Tag: ${{ steps.meta.outputs.tags }}'
         echo 'Label: ${{ steps.meta.labels.tags }}'
 
-    # - name: Build and push Docker image
-    #   uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-    #   with:
-    #     context: <go or python>
-    #     push: true
-    #     tags: ${{ steps.meta.outputs.tags }}
-    #     labels: ${{ steps.meta.outputs.labels }}
+    - name: Build and push Docker image
+      uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+      with:
+        context: go
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -1,8 +1,19 @@
-FROM alpine
+FROM golang:1.24.0-alpine3.20
 
-RUN addgroup -S mercari && adduser -S trainee -G mercari
-# RUN chown -R trainee:mercari /path/to/db
+ENV CGO_ENABLED=1
+
+RUN apk add --no-cache gcc musl-dev sqlite
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+# ユーザー・グループの作成と権限設定
+RUN addgroup -S mercari && adduser -S trainee -G mercari \
+    && chown -R trainee:mercari db 
 
 USER trainee
 
-CMD ["go", "version"]
+CMD ["go", "run", "cmd/api/main.go"]


### PR DESCRIPTION
## What
- Enable GitHub Actions (8-2)
- Build the application with GitHub Actions and upload the docker image to the registry (8-3)
- Pull the image locally and run it (8-3)

## Prove
- 8-2
![スクリーンショット 2025-03-07 1 56 13](https://github.com/user-attachments/assets/14043870-4b3d-4950-b776-64085ad76850)
- 8-3
<img width="911" alt="スクリーンショット 2025-03-07 2 26 57" src="https://github.com/user-attachments/assets/1334d075-d62f-4acc-957c-f0958d568093" />

<img width="951" alt="スクリーンショット 2025-03-07 2 26 10" src="https://github.com/user-attachments/assets/386d3edb-4a80-4939-a3c0-2c65b55e9a86" />
